### PR TITLE
Handle button events without valid ID code

### DIFF
--- a/skse64/PapyrusEvents.cpp
+++ b/skse64/PapyrusEvents.cpp
@@ -211,10 +211,6 @@ EventResult InputEventHandler::ReceiveEvent(InputEvent ** evns, InputEventDispat
 					else
 						keyCode = keyMask;
 
-					// Valid scancode?
-					if (keyCode >= InputMap::kMaxMacros)
-						continue;
-
 					BSFixedString	control	= *t->GetControlID();
 					float			timer	= t->timer;
 
@@ -226,27 +222,38 @@ EventResult InputEventHandler::ReceiveEvent(InputEvent ** evns, InputEventDispat
 						// Used by scaleform skse.GetLastControl
 						SetLastControlDown(control.data, keyCode);
 
-						g_inputKeyEventRegs.ForEach(
-							keyCode,
-							EventQueueFunctor1<SInt32>(BSFixedString("OnKeyDown"), (SInt32)keyCode)
+						// Valid scancode?
+						if (keyCode < InputMap::kMaxMacros) {
+							g_inputKeyEventRegs.ForEach(
+								keyCode,
+								EventQueueFunctor1<SInt32>(BSFixedString("OnKeyDown"), (SInt32)keyCode)
 							);
-						g_inputControlEventRegs.ForEach(
-							control,
-							EventQueueFunctor1<BSFixedString>(BSFixedString("OnControlDown"), control)
+						}
+
+						if (strlen(control.c_str()) > 0) {
+							g_inputControlEventRegs.ForEach(
+								control,
+								EventQueueFunctor1<BSFixedString>(BSFixedString("OnControlDown"), control)
 							);
+						}
 					}
 					else if (isUp)
 					{
 						SetLastControlUp(control.data, keyCode);
 
-						g_inputKeyEventRegs.ForEach(
-							keyCode,
-							EventQueueFunctor2<SInt32, float>(BSFixedString("OnKeyUp"), (SInt32)keyCode, timer)
+						if (keyCode < InputMap::kMaxMacros) {
+							g_inputKeyEventRegs.ForEach(
+								keyCode,
+								EventQueueFunctor2<SInt32, float>(BSFixedString("OnKeyUp"), (SInt32)keyCode, timer)
 							);
-						g_inputControlEventRegs.ForEach(
-							control,
-							EventQueueFunctor2<BSFixedString, float>(BSFixedString("OnControlUp"), control, timer)
+						}
+
+						if (strlen(control.c_str()) > 0) {
+							g_inputControlEventRegs.ForEach(
+								control,
+								EventQueueFunctor2<BSFixedString, float>(BSFixedString("OnControlUp"), control, timer)
 							);
+						}
 					}
 				}
 				break;


### PR DESCRIPTION
I'm working on making a mod that needs to dispatch user events (AKA controls) that may not necessarily have an ID code. The base game happily accepts these inputs, but when SKSE receives them, it doesn't update the last control for Scaleform, nor dispatch control events to Papyrus. This can also cause weird issues in SkyUI, like treating every input as the same control because  it's not updated.

I don't think I have a good way to work around the issue on my end, so I'm submitting this patch for how I believe this edge case should be handled. If there is no valid ID code, it will still update for Scaleform, and only block the key event for Papyrus, while still sending the control event. I also added an extra check that the string isn't empty for sending a control event, but I would be okay with reverting that if it's not desired behavior.