### PR TITLE
Script Optimizations

### DIFF
--- a/scripts/vanilla/Actor.psc
+++ b/scripts/vanilla/Actor.psc
@@ -25,16 +25,17 @@ endFunction
 
 ; also DEPRECATED
 Function ModFavorPointsWithGlobal(GlobalVariable FavorPointsGlobal)
-	ModFavorPoints(FavorPointsGlobal.GetValueInt())
+	ModFavorPoints(FavorPointsGlobal.GetValue() as int)
 endFunction
 
 ;this function will make an actor a friend of the player if allowed
 Function MakePlayerFriend()
-	ActorBase myBase = GetActorBase()
+	ActorBase myBase = GetBaseObject() as ActorBase
 	if myBase.IsUnique()
-		if GetRelationshipRank(Game.GetPlayer())== 0
+		Actor plyr = game.GetPlayer()
+		if GetRelationshipRank(plyr) == 0
 ; 			debug.trace(self + " MakePlayerFriend called on neutral actor - changed to FRIEND.")
-			SetRelationshipRank(Game.GetPlayer(), 1)
+			SetRelationshipRank(plyr, 1)
 		else
 ; 			debug.trace(self + " MakePlayerFriend called on non-neutral actor - NO EFFECT.")
 		endif

--- a/scripts/vanilla/ObjectReference.psc
+++ b/scripts/vanilla/ObjectReference.psc
@@ -8,23 +8,24 @@ bool FUNCTION rampRumble(float power = 0.5, float duration = 0.25, float falloff
 ; 		debug.traceStack(self + " called rampRumble() but parameter 'power' was invalid.  Must be a non-zero float less than 1.0",1)
 		; throw the warning, but don't return false - value gets clamped anyway
 	endif
-	float playerDist = game.getplayer().getDistance(self)
+    Actor plyr = game.GetPlayer()
+	float playerDist = (plyr).getDistance(self)
 	; ignore if the player is too far away
 	if playerDist < falloff
-		float intensity = (1 - (playerDist / falloff))
+		float intensity = (1.0 - (playerDist / falloff))
 		; ramp actual intensity down based on parameter value
 		intensity = intensity*power		
 		if intensity > 1.0
 			; clamp to prevent invalid values
 ; 			debug.traceStack(self + " called for too much controller/camera shake.  Clamped to 1.0", 0)
 			intensity = 1.0 
-		elseif intensity <= 0
+		elseif intensity <= 0.0
 			; clamp to prevent invalid values
 ; 			debug.traceStack(self + " called for too little controller/camera shake", 0)
-			intensity = 0
+			intensity = 0.0
 			return false
 		endif
-		game.shakeCamera(game.getPlayer(), intensity)
+		game.shakeCamera(plyr, intensity)
 		game.shakeController(intensity, intensity, duration)
 		return true
 	else
@@ -48,7 +49,7 @@ bool Function IsNearPlayer()
 		else
 			; both in an exterior -- no means of testing 
 			;  worldspace at the moment, so this will do.
-			if (player.GetDistance(self) > 3000)
+			if (player.GetDistance(self) > 3000.0)
 				; pretty darned far away -- safe
 				return false
 			else
@@ -86,7 +87,7 @@ function MoveToWhenUnloaded(ObjectReference akTarget, float afXOffset = 0.0, flo
 	while self.GetCurrentLocation().IsLoaded() || akTarget.GetCurrentLocation().IsLoaded()
 		;do nothing
 ; 		debug.trace(self + "MoveToWhenUnloaded() waiting for current location and target location to be unloaded before moving. If called by a quest stage fragment, this may cause that quest stage to not complete until this function finishes (and if it's a startup stage, the quest will not report itself as running until the stage finishes.).", 1)
-		Utility.Wait(5)	;when this function is threaded we can increase this wait time... I set it lower for testing purposes so it reevaluates faster when I need to purge cell buffers in the Civil War when calling moveto on the player between Civil War campaigns
+		Utility.Wait(5.0)	;when this function is threaded we can increase this wait time... I set it lower for testing purposes so it reevaluates faster when I need to purge cell buffers in the Civil War when calling moveto on the player between Civil War campaigns
 	EndWhile
 	self.MoveTo(akTarget, afXOffset, afYOffset, afZOffset)
 EndFunction
@@ -97,7 +98,7 @@ Function DeleteWhenAble()
 	While GetParentCell() && GetParentCell().IsAttached()
 		;do nothing
 ; 		debug.trace(self + "DeleteWhenAble() waiting for current location to be unloaded before deleting. If called by a quest stage fragment, this may cause that quest stage to not complete until this function finishes (and if it's a startup stage, the quest will not report itself as running until the stage finishes.).", 1)
-		Utility.Wait(5) ;when this function is threaded we can increase this wait time... I set it lower for testing purposes so it reevaluates faster when I need to purge cell buffers in the Civil War when calling moveto on the player between Civil War campaigns
+		Utility.Wait(5.0) ;when this function is threaded we can increase this wait time... I set it lower for testing purposes so it reevaluates faster when I need to purge cell buffers in the Civil War when calling moveto on the player between Civil War campaigns
 	EndWhile
 	Delete()
 EndFunction

--- a/scripts/vanilla/Quest.psc
+++ b/scripts/vanilla/Quest.psc
@@ -14,7 +14,7 @@ bool Function ModObjectiveGlobal(float afModValue, GlobalVariable aModGlobal, in
 	UpdateCurrentInstanceGlobal(aModGlobal)
 	if aiObjectiveID >= 0
 		; display/complete objectives automatically
-		if afTargetValue > -1
+		if afTargetValue > -1.0
 			if (abCountingUp && aModGlobal.value >= afTargetValue) || (!abCountingUp && aModGlobal.value <= afTargetValue)
 				if (abCompleteObjective)
 					; complete objective

--- a/scripts/vanilla/ReferenceAlias.psc
+++ b/scripts/vanilla/ReferenceAlias.psc
@@ -44,16 +44,18 @@ endFunction
 
 ; Convenience fucntion
 Actor Function GetActorRef()
-	return GetActorReference()
+	return GetReference() as Actor
 endFunction
 
 
 ; Convenience function - jduvall
 bool Function TryToAddToFaction(Faction FactionToAddTo)
-	Actor ActorRef = GetActorReference()
+	Actor ActorRef = GetReference() as Actor
 	
 	if ActorRef
-		ActorRef.AddToFaction(FactionToAddTo)
+		if (!ActorRef.IsInFaction(FactionToAddTo))
+			ActorRef.SetFactionRank(FactionToAddTo, 0)
+		endif
 		Return True
 	EndIf
 
@@ -62,7 +64,7 @@ EndFunction
 
 ; Convenience function - jduvall
 bool Function TryToRemoveFromFaction(Faction FactionToRemoveFrom)
-	Actor ActorRef = GetActorReference()
+	Actor ActorRef = GetReference() as Actor
 	
 	if ActorRef
 		ActorRef.RemoveFromFaction(FactionToRemoveFrom)
@@ -74,7 +76,7 @@ EndFunction
 
 ; Convenience function - jduvall
 bool Function TryToStopCombat()
-	Actor ActorRef = GetActorReference()
+	Actor ActorRef = GetReference() as Actor
 	
 	if ActorRef
 		ActorRef.StopCombat()
@@ -134,7 +136,7 @@ EndFunction
 
 ; Convenience function - jduvall
 bool Function TryToEvaluatePackage()
-	Actor ActorRef = GetActorReference()
+	Actor ActorRef = GetReference() as Actor
 	
 	if ActorRef
 		ActorRef.EvaluatePackage()
@@ -146,7 +148,7 @@ EndFunction
 
 ; Convenience function - jduvall
 bool Function TryToKill()
-	Actor ActorRef = GetActorReference()
+	Actor ActorRef = GetReference() as Actor
 	
 	if ActorRef
 		ActorRef.Kill()


### PR DESCRIPTION
- Casting to float from int is about 10% slower then just using a float.(X -> X.0)
- The VM doesn't seem to inline at all. So the function overhead for GetActorRef() is three times what  GetReference() is. The overhead is most of the script delay. So I manually inlined them.

I emailed you(Ian) a long time ago about this.  I just recently got to this since the new Skyrim version stuff is heating up. and that would mean a new SKSE version.