### PR TITLE
Addresses issues with PapyrusActorValueInfo::GetPerk.* implementation.

### DIFF
--- a/skse64/GameFormComponents.h
+++ b/skse64/GameFormComponents.h
@@ -1332,7 +1332,7 @@ public:
 		virtual bool Accept(BGSPerk * node) = 0;
 	};
 
-	bool VisitPerks(PerkVisitor & visitor)
+	bool VisitPerks(PerkVisitor & visitor, const int depth = 0)
 	{
 		if(visitor.Accept(perk))
 			return true;
@@ -1342,7 +1342,7 @@ public:
 			BGSSkillPerkTreeNode* connector = NULL;
 			connections.GetNthItem(i, connector);
 
-			if(connector->VisitPerks(visitor))
+			if(depth < 32 && connector->VisitPerks(visitor, depth + 1))
 				return true;
 		}
 

--- a/skse64/PapyrusActorValueInfo.cpp
+++ b/skse64/PapyrusActorValueInfo.cpp
@@ -17,36 +17,11 @@ public:
 	{
 		if(perk && !GetPerkAdded(perk))
 		{
-			bool addPerk = true;
-			if(m_actor) {
-				if(!CALL_MEMBER_FN(m_actor, HasPerk)(perk))
-					addPerk = m_unowned;
-				else
-					addPerk = !m_unowned;
-			}
-
-			if(addPerk) {
-				AddPerk(perk);
-			}
-
-			if(m_allRanks) {
-				BGSPerk * nextPerk = perk->nextPerk;
-				while(nextPerk) {
-					addPerk = true;
-					if(m_actor) {
-						if(!CALL_MEMBER_FN(m_actor, HasPerk)(nextPerk))
-							addPerk = m_unowned;
-						else
-							addPerk = !m_unowned;
-					}
-
-					if(addPerk) {
-						AddPerk(nextPerk);
-					}
-
-					nextPerk = nextPerk->nextPerk;
-				}
-			}
+			do
+			{	if (!m_actor || (!CALL_MEMBER_FN(m_actor, HasPerk)(perk) ? m_unowned : !m_unowned) )
+					AddPerk(perk);
+				perk = m_allRanks ? perk->nextPerk : nullptr;
+			}	while (perk);
 		}
 
 		return false;

--- a/skse64/PapyrusActorValueInfo.cpp
+++ b/skse64/PapyrusActorValueInfo.cpp
@@ -15,7 +15,7 @@ public:
 
 	virtual bool Accept(BGSPerk * perk)
 	{
-		if(perk)
+		if(perk && !GetPerkAdded(perk))
 		{
 			bool addPerk = true;
 			if(m_actor) {
@@ -52,6 +52,7 @@ public:
 		return false;
 	}
 	virtual void AddPerk(BGSPerk * perk) = 0;
+	virtual bool GetPerkAdded(BGSPerk *perk) = 0;
 };
 
 class PerkFormListVisitor : public MatchSkillPerks
@@ -67,6 +68,13 @@ public:
 	{
 		CALL_MEMBER_FN(m_formList, AddFormToList)(perk);
 	}
+
+	virtual bool GetPerkAdded(BGSPerk *perk)
+	{
+		TESForm *base = perk;
+
+		return ((*m_formList).forms.GetItemIndex(base) > -1);
+	}
 };
 
 class PerkArrayVisitor : public MatchSkillPerks
@@ -80,6 +88,17 @@ public:
 	virtual void AddPerk(BGSPerk * perk)
 	{
 		m_perks->push_back(perk);
+	}
+	virtual bool GetPerkAdded(BGSPerk *perk)
+	{
+		std::vector<BGSPerk*>::const_iterator offbounds = (*m_perks).cend();
+
+		for (std::vector<BGSPerk*>::const_iterator i = (*m_perks).cbegin(); i != offbounds; ++i)
+		{	if (*i != perk)
+				continue ;
+			return (true);
+		}
+		return (false);
 	}
 };
 


### PR DESCRIPTION
_Hello Ian_,

_First of all, my earnest apologies for the misunderstanding before. I made unrealistic assumptions based on PRs history. Please, take as long you need to review these and any future patches. Whether it takes a month or a year, I'm here if you've any questions/concerns/comments._

_Cheers_.


### Rationale
In its current implementation, PapyrusActorValueInfo::GetPerkxxx functions can generate a stack overflow when traversing a malformed perk tree with cyclically linked nodes.  e.g https://www.nexusmods.com/skyrimspecialedition/mods/20605. These patches address the issue by establishing a max recursion depth limit. Additionally, the added perks are checked to avoid repetitions in the resulting perk array, which is something that can happen even with conventional perk trees.

The last patch doesn't fix anything, it's just an "improvement" I made while I was debugging that section. Feel free to Ignore or merge it, if you feel so inclined.