### PR TITLE
Extends the SE component with various Papyrus additions.

### DIFF
--- a/scripts/modified/ObjectReference.psc
+++ b/scripts/modified/ObjectReference.psc
@@ -12,20 +12,6 @@
 ;	Usage: player.AddItemsBulk(item_list, items_count)
 bool Function AddItemsBulk(Form[] items, int[] count, bool remove = false) native
 
-;Returns how many instances of the passed form are present in the container (-1 if the container was not scanned).
-;Container contents are cached in the first call and subsequent calls return the cached values instead of querying the
-;container again. Intended as a faster alternative to GetItemCount, to be used when several calls are required in quick
-;succession and the contents of the container are not expected to change.
-;NOTES:
-;If called on a different container from last, the cache is rebuilt from the new container before looking up the item.
-;If refresh is true, the cache is rebuilt before looking up the item.
-;If item is NONE, the cache is cleared and -1 is returned.
-;The function is bottlenecked by frametime, which at a typical avg of 16ms, only allows ~60 calls per second.
-;While faster than "GetItemCount", which only manages ~10-14 calls per second, it's still not be ideal if processing
-;many items in a time sensitive manner. Consider using the new GetItemsCount in such circumstances.
-;	Usage: container.GetItemCountCached(my_item)
-int Function GetItemCountCached(Form item, bool rebuild = false) native
-
 ;Returns an array, each element containing the number of instances of items[x] present in the container.
 ;The array is filled in such a way that its first element will contain the count of items' first element, and so on.
 ;Intended to be used when large quantities of items need to be processed as fast as possible.

--- a/scripts/modified/ObjectReference.psc
+++ b/scripts/modified/ObjectReference.psc
@@ -1,9 +1,46 @@
 
 ; Container-only functions
+
+;Adds or removes count[i] instances of items[i] to the container.
+;Intended as a fast way to add large quantity of items to a container in a single operation.
+;It has the added benefit of avoiding OnItemAdded/removed events which can cause stack dumps on an overwhelmed VM.
+;Returns true if items were added, false otherwise.
+;NOTES:
+;1. Extra data will not be copied, which makes this unsuitable for adding tempered/enchanted equipment.
+;2. Removing equipped items from an actor will result in undefined behavior. Un-equip them first.
+;3. If items[] and count[] don't have the same size, the function will perform no task.
+;	Usage: player.AddItemsBulk(item_list, items_count)
+bool Function AddItemsBulk(Form[] items, int[] count, bool remove = false) native
+
+;Returns how many instances of the passed form are present in the container (-1 if the container was not scanned).
+;Container contents are cached in the first call and subsequent calls return the cached values instead of querying the
+;container again. Intended as a faster alternative to GetItemCount, to be used when several calls are required in quick
+;succession and the contents of the container are not expected to change.
+;NOTES:
+;If called on a different container from last, the cache is rebuilt from the new container before looking up the item.
+;If refresh is true, the cache is rebuilt before looking up the item.
+;If item is NONE, the cache is cleared and -1 is returned.
+;The function is bottlenecked by frametime, which at a typical avg of 16ms, only allows ~60 calls per second.
+;While faster than "GetItemCount", which only manages ~10-14 calls per second, it's still not be ideal if processing
+;many items in a time sensitive manner. Consider using the new GetItemsCount in such circumstances.
+;	Usage: container.GetItemCountCached(my_item)
+int Function GetItemCountCached(Form item, bool rebuild = false) native
+
+;Returns an array, each element containing the number of instances of items[x] present in the container.
+;The array is filled in such a way that its first element will contain the count of items' first element, and so on.
+;Intended to be used when large quantities of items need to be processed as fast as possible.
+;	Usage: container.GetItemsCount(item_list)
+Int[] Function GetItemsCount(Form[] items) native
+
 int Function GetNumItems() native
 Form Function GetNthForm(int index) native
 float Function GetTotalItemWeight() native
 float Function GetTotalArmorWeight() native
+
+;Returns the final cost of the item as shown in the UI, after factors like enchantments and tempering are calculated.
+;If there's more than one instance of the same form in the container, only the first one is returned.
+;	Usage: container.GetDisplayValue(my_item)
+int Function GetDisplayValue(Form item) native
 
 ; Tree and Flora only functions
 bool Function IsHarvested() native
@@ -21,6 +58,13 @@ float Function GetItemMaxCharge() native
 
 float Function GetItemCharge() native
 Function SetItemCharge(float charge) native
+
+;Restores the charge of the passed weapon if found in the container.
+;If "all" is set to true, every enchanted instance found will be recharged, otherwise only the first one will.
+;Returns how much charge was restored to the weapon(s).
+;Works only on weapons inside a container. Accepts forms as long as the form can be cast to weapon.
+;	Usage: container.RestoreItemCharge(myWeapon)
+float Function RestoreItemCharge(Weapon wepn, bool all) native
 
 Function ResetInventory() native
 

--- a/scripts/modified/Perk.psc
+++ b/scripts/modified/Perk.psc
@@ -1,5 +1,9 @@
 Perk Function GetNextPerk() native
 
+;Returns the required skill level necessary to acquire this perk
+;e.g Flurry.GetSkillRequirement("OneHanded")
+int Function GetSkillRequirement(string actorvalue) native
+
 int Function GetNumEntries() native
 
 int Function GetNthEntryRank(int n) native

--- a/skse64/PapyrusObjectReference.cpp
+++ b/skse64/PapyrusObjectReference.cpp
@@ -292,7 +292,7 @@ namespace papyrusObjectReference
 		return (false);
 	} 
 
-	SInt32 GetItemCountCached(TESObjectREFR *src, TESForm *item, const bool refresh = false)
+	static SInt32 GetItemCountCached(TESObjectREFR *src, TESForm *item, const bool refresh = false)
 	{
 		static std::map<TESForm*, SInt32> cache;
 		static TESObjectREFR *last = nullptr;
@@ -724,9 +724,6 @@ void papyrusObjectReference::RegisterFuncs(VMClassRegistry* registry)
 
 	registry->RegisterFunction(
 		new NativeFunction1<TESObjectREFR, VMResultArray<UInt32>, VMArray<TESForm*> >("GetItemsCount", "ObjectReference", papyrusObjectReference::GetItemsCount, registry));
-
-	registry->RegisterFunction(
-		new NativeFunction2<TESObjectREFR, SInt32, TESForm*, bool>("GetItemCountCached", "ObjectReference", papyrusObjectReference::GetItemCountCached, registry));
 
 	registry->RegisterFunction(
 		new NativeFunction1<TESObjectREFR, TESForm*, UInt32>("GetNthForm", "ObjectReference", papyrusObjectReference::GetNthForm, registry));

--- a/skse64/PapyrusObjectReference.cpp
+++ b/skse64/PapyrusObjectReference.cpp
@@ -251,7 +251,8 @@ namespace papyrusObjectReference
 		ExtraContainerChanges *dst = (ExtraContainerChanges*)(*container).extraData.GetByType(kExtraData_ContainerChanges);
 
 		if (dst && (*dst).data && (*(*dst).data).objList && forms.Length() == counts.Length() )
-		{	InventoryEntryData	*entry;
+		{	TESContainer		*basecont = DYNAMIC_CAST((*container).baseForm, TESForm, TESContainer);
+			InventoryEntryData	*entry;
 			TESForm				*item;
 			SInt32				count;
 
@@ -261,6 +262,7 @@ namespace papyrusObjectReference
 				if (!item || count <= 0)
 					continue ;
 				tList<InventoryEntryData>::Iterator lst = (*(*(*dst).data).objList).Begin();
+				const SInt32 static_cnt = basecont ? (*basecont).CountItem(item) : 0;
 
 				while ((entry = lst.Get() ) && (*entry).type != item)
 					++lst;
@@ -273,11 +275,12 @@ namespace papyrusObjectReference
 					case 0b01:
 					break ;
 					case 0b10:
-						if (((*entry).countDelta += count) < count)
+						if (((*entry).countDelta += count) + static_cnt < count)
 							(*entry).countDelta += (count - (*entry).countDelta);
 					break ;
 					case 0b11:
-						if (((*entry).countDelta -= count) <= 0)
+						(*entry).countDelta -= count;
+						if (!static_cnt ? (*entry).countDelta < 1 : (*entry).countDelta == 0)
 						{	(*(*(*dst).data).objList).Remove(entry);
 							(*entry).Delete();
 						}

--- a/skse64/PapyrusObjectReference.h
+++ b/skse64/PapyrusObjectReference.h
@@ -5,6 +5,7 @@
 
 class TESObjectREFR;
 class TESForm;
+class TESObjectWEAP;
 class EnchantmentItem;
 class VMClassRegistry;
 class EffectSetting;
@@ -13,7 +14,10 @@ class BGSListForm;
 namespace papyrusObjectReference
 {
 	void RegisterFuncs(VMClassRegistry* registry);
+	bool AdditemsBulk(TESObjectREFR* pContainerRef, VMArray<TESForm*> items, VMArray<SInt32> counts, bool remove);
 	UInt32 GetNumItems(TESObjectREFR* pContainerRef);
+	VMResultArray<UInt32> GetItemsCount(TESObjectREFR *pContainerRef, VMArray<TESForm*> items);
+	SInt32 GetItemCountCached(TESObjectREFR *pContainerRef, TESForm *item, const bool refresh);
 	TESForm* GetNthForm(TESObjectREFR* pContainerRef, UInt32 n);
 	float GetTotalItemWeight(TESObjectREFR* pContainerRef);
 	float GetTotalArmorWeight(TESObjectREFR* pContainerRef);
@@ -22,6 +26,7 @@ namespace papyrusObjectReference
 	float GetItemCharge(TESObjectREFR* object);
 	float GetItemMaxCharge(TESObjectREFR* object);
 	void SetItemCharge(TESObjectREFR* object, float value);
+	float RestoreItemCharge(TESObjectREFR*, TESObjectWEAP*, bool);
 	EnchantmentItem * GetEnchantment(TESObjectREFR* object);
 
 	void CreateEnchantment(TESObjectREFR* object, float maxCharge, VMArray<EffectSetting*> effects, VMArray<float> magnitudes, VMArray<UInt32> areas, VMArray<UInt32> durations);
@@ -31,6 +36,7 @@ namespace papyrusObjectReference
 	bool IsOffLimits(TESObjectREFR * obj);
 	BSFixedString GetDisplayName(TESObjectREFR* object);
 	bool SetDisplayName(TESObjectREFR* object, BSFixedString value, bool force);
+	UInt32 GetDisplayValue(TESObjectREFR *pContainerRef, TESForm *item);
 	TESObjectREFR * GetEnableParent(TESObjectREFR* object);
 
 	bool IsHarvested(TESObjectREFR* pProduceRef);

--- a/skse64/PapyrusObjectReference.h
+++ b/skse64/PapyrusObjectReference.h
@@ -17,7 +17,6 @@ namespace papyrusObjectReference
 	bool AdditemsBulk(TESObjectREFR* pContainerRef, VMArray<TESForm*> items, VMArray<SInt32> counts, bool remove);
 	UInt32 GetNumItems(TESObjectREFR* pContainerRef);
 	VMResultArray<UInt32> GetItemsCount(TESObjectREFR *pContainerRef, VMArray<TESForm*> items);
-	SInt32 GetItemCountCached(TESObjectREFR *pContainerRef, TESForm *item, const bool refresh);
 	TESForm* GetNthForm(TESObjectREFR* pContainerRef, UInt32 n);
 	float GetTotalItemWeight(TESObjectREFR* pContainerRef);
 	float GetTotalArmorWeight(TESObjectREFR* pContainerRef);

--- a/skse64/PapyrusPerk.cpp
+++ b/skse64/PapyrusPerk.cpp
@@ -3,12 +3,33 @@
 #include "GameForms.h"
 #include "GameObjects.h"
 #include "GameRTTI.h"
+#include "GameData.h"
 
 namespace papyrusPerk
 {
 	BGSPerk * GetNextPerk(BGSPerk * perk)
 	{
 		return (perk) ? perk->nextPerk : NULL;
+	}
+
+	UInt32 GetSkillRequirement(BGSPerk *perk, BSFixedString actorvalue)
+	{
+		if (perk && (*perk).conditions)
+		{	constexpr unsigned	NOT_GREATER_OR_EQUAL = 0X9fU;
+			constexpr UInt16	GET_BASE_AV = 0X115;
+			Condition			*current = (*perk).conditions;
+			const UInt32		id = ActorValueList::ResolveActorValueByName(actorvalue.data);
+
+			while (current)
+			{	if ((*current).functionId != GET_BASE_AV
+				|| (((*current).comparisonType) & NOT_GREATER_OR_EQUAL) || (id && (*current).param1 != id) )
+				{	current = (*current).next;
+					continue;
+				}
+				return ((UInt32)(int)*(float*)&(*current).compareValue);
+			}
+		}
+		return (0);
 	}
 
 	UInt32 GetNumEntries(BGSPerk * perk)
@@ -353,6 +374,9 @@ void papyrusPerk::RegisterFuncs(VMClassRegistry* registry)
 {
 	registry->RegisterFunction(
 		new NativeFunction0<BGSPerk, BGSPerk*>("GetNextPerk", "Perk", papyrusPerk::GetNextPerk, registry));
+
+	registry->RegisterFunction(
+		new NativeFunction1<BGSPerk, UInt32, BSFixedString>("GetSkillRequirement", "Perk", papyrusPerk::GetSkillRequirement, registry));
 
 	registry->RegisterFunction(
 		new NativeFunction0<BGSPerk, UInt32>("GetNumEntries", "Perk", papyrusPerk::GetNumEntries, registry));

--- a/skse64/PapyrusPerk.h
+++ b/skse64/PapyrusPerk.h
@@ -13,6 +13,7 @@ namespace papyrusPerk
 	void RegisterFuncs(VMClassRegistry* registry);
 
 	BGSPerk * GetNextPerk(BGSPerk * perk);
+	UInt32 GetSkillRequirement(BGSPerk *perk, BSFixedString actorvalue);
 	UInt32 GetNumEntries(BGSPerk * perk);
 	UInt32 GetNthEntryRank(BGSPerk * perk, UInt32 n);
 	UInt32 GetNthEntryPriority(BGSPerk * perk, UInt32 n);


### PR DESCRIPTION
### Synopsis


**bool AddItemsBulk(Form[] items, int[] count, bool remove = false)**
_Adds to -or removes from- the container, count instances of the passed forms in a single operation. Mass addition/removal of items can also be achieved by the native AddItems if given a formlist as argument, but this will quickly send OnItemAdded notifications to all listeners, which can overwhelm the VM resulting in stack dumps and massive slowdowns. This function avoids that undesired side effect, and offers the added benefits of not requiring formlists and  allowing fine tuning of the added/removed amounts._

**int container.GetItemCountCached(Form item, bool refresh = false)**
_Upon the first call, the contents of the container are cached and subsequent calls simply retrieve the cached value without looking up the container. Much faster than the native GetItemCount. Intended for use when successive calls are required and the container's contents are known not to change._

**int[] GetItemsCount(Form[] items]**
_Due to the frametime sync call overhead, GetItemCountCached is unsuitable for processing large arrays of items. This wrapper uses GetItemCountCached internally to processes an entire array in a single call and -usually- frame._

**float RestoreItemCharge(Weapon wepn, bool all = false)**
_While there are other charge functions, this one works directly on forms inside containers. It restores and returns the missing charge of the first pertinent entry in the extradata list. Or all of them if _all_  is true._

**float GetDisplayValue(form item) native**
_There's already a function that returns a form's base value, however the final value can vary widely from this amount depending on enchantments, temper status and other factors. This function returns the real display value, as shown on the UI._

**int GetSkillRequirement(string actorvalue)**
_Returns the skill level needed to acquire this perk._